### PR TITLE
Fix free of uninitialized pointers

### DIFF
--- a/src/zip.c
+++ b/src/zip.c
@@ -517,11 +517,12 @@ bool zip_append_file(zip *z, const char *entryname, FILE *in, unsigned compress_
     e->header.externalFileAttributes = 0x20; // whatever this is
     e->header.relativeOffsetOflocalHeader = ftell(z->out);
 
+    void *comp = 0, *data = 0;
+
     if(!compress_level) goto dont_compress;
 
     // Read whole file and and use compress(). Simple but won't handle GB files well.
     unsigned dataSize = e->header.uncompressedSize, compSize = BOUNDS(e->header.uncompressedSize, compress_level);
-    void *comp = 0, *data = 0;
 
     comp = REALLOC(0, compSize);
     if(comp == NULL) goto cant_compress;


### PR DESCRIPTION
If you call `zip_append_file` with `compress_level = 0` it jumps over initialization of `void* comp` and `void* data`:

https://github.com/r-lyeh/stdarc.c/blob/6f6a6de53c59bcdd4091020e6e68ee065e31107c/src/zip.c#L520-L524

At the end of the procedure they always get freed:

https://github.com/r-lyeh/stdarc.c/blob/6f6a6de53c59bcdd4091020e6e68ee065e31107c/src/zip.c#L572-L574